### PR TITLE
Add /block endpoint (without transactions)

### DIFF
--- a/kava/client.go
+++ b/kava/client.go
@@ -177,6 +177,7 @@ func (c *Client) Balance(
 	}, nil
 }
 
+// Block returns rosetta block for an index or hash
 func (c *Client) Block(
 	ctx context.Context,
 	blockIdentifier *types.PartialBlockIdentifier,

--- a/kava/client.go
+++ b/kava/client.go
@@ -201,6 +201,8 @@ func (c *Client) Block(
 	}, nil
 }
 
+// getBlockResult returns the specified block by Index or Hash. If the
+// block identifier is not provided, then the latest block is returned
 func (c *Client) getBlockResult(blockIdentifier *types.PartialBlockIdentifier) (block *ctypes.ResultBlock, err error) {
 	switch {
 	case blockIdentifier == nil:

--- a/kava/client.go
+++ b/kava/client.go
@@ -204,6 +204,7 @@ func (c *Client) Block(
 func (c *Client) getBlockResult(blockIdentifier *types.PartialBlockIdentifier) (block *ctypes.ResultBlock, err error) {
 	switch {
 	case blockIdentifier == nil:
+		// fetch the latest block by passing (*int64)(nil) to tendermint rpc
 		block, err = c.rpc.Block(nil)
 	case blockIdentifier.Index != nil:
 		block, err = c.rpc.Block(blockIdentifier.Index)

--- a/kava/client.go
+++ b/kava/client.go
@@ -202,12 +202,27 @@ func (c *Client) Block(
 		return nil, err
 	}
 
+	height := block.Block.Header.Height
+	identifier := &types.BlockIdentifier{
+		Index: height,
+		Hash:  block.BlockID.Hash.String(),
+	}
+
+	var parentIdentifier *types.BlockIdentifier
+	if height == 1 {
+		parentIdentifier = identifier
+	} else {
+		parentIdentifier = &types.BlockIdentifier{
+			Index: height - 1,
+			Hash:  block.Block.Header.LastBlockID.Hash.String(),
+		}
+	}
+
 	return &types.BlockResponse{
 		Block: &types.Block{
-			BlockIdentifier: &types.BlockIdentifier{
-				Index: block.Block.Header.Height,
-				Hash:  block.BlockID.Hash.String(),
-			},
+			BlockIdentifier:       identifier,
+			ParentBlockIdentifier: parentIdentifier,
+			Timestamp:             block.Block.Header.Time.UnixNano() / int64(1e6),
 		},
 	}, nil
 }

--- a/kava/client.go
+++ b/kava/client.go
@@ -17,6 +17,7 @@ package kava
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -175,4 +176,11 @@ func (c *Client) Balance(
 		},
 		Balances: balances,
 	}, nil
+}
+
+func (c *Client) Block(
+	ctx context.Context,
+	blockIdentifier *types.PartialBlockIdentifier,
+) (*types.BlockResponse, error) {
+	return nil, errors.New("not implemented")
 }

--- a/kava/client.go
+++ b/kava/client.go
@@ -223,6 +223,7 @@ func (c *Client) Block(
 			BlockIdentifier:       identifier,
 			ParentBlockIdentifier: parentIdentifier,
 			Timestamp:             block.Block.Header.Time.UnixNano() / int64(1e6),
+			Transactions:          []*types.Transaction{},
 		},
 	}, nil
 }

--- a/kava/client.go
+++ b/kava/client.go
@@ -116,19 +116,7 @@ func (c *Client) Balance(
 		return nil, err
 	}
 
-	var block *ctypes.ResultBlock
-	switch {
-	case blockIdentifier == nil:
-		block, err = c.rpc.Block(nil)
-	case blockIdentifier.Index != nil:
-		block, err = c.rpc.Block(blockIdentifier.Index)
-	case blockIdentifier.Hash != nil:
-		hashBytes, decodeErr := hex.DecodeString(*blockIdentifier.Hash)
-		if decodeErr != nil {
-			return nil, decodeErr
-		}
-		block, err = c.rpc.BlockByHash(hashBytes)
-	}
+	block, err := c.getBlockResult(blockIdentifier)
 	if err != nil {
 		return nil, err
 	}
@@ -182,23 +170,7 @@ func (c *Client) Block(
 	ctx context.Context,
 	blockIdentifier *types.PartialBlockIdentifier,
 ) (*types.BlockResponse, error) {
-	var (
-		block *ctypes.ResultBlock
-		err   error
-	)
-
-	switch {
-	case blockIdentifier == nil:
-		block, err = c.rpc.Block(nil)
-	case blockIdentifier.Index != nil:
-		block, err = c.rpc.Block(blockIdentifier.Index)
-	case blockIdentifier.Hash != nil:
-		hashBytes, decodeErr := hex.DecodeString(*blockIdentifier.Hash)
-		if decodeErr != nil {
-			return nil, decodeErr
-		}
-		block, err = c.rpc.BlockByHash(hashBytes)
-	}
+	block, err := c.getBlockResult(blockIdentifier)
 	if err != nil {
 		return nil, err
 	}
@@ -227,4 +199,21 @@ func (c *Client) Block(
 			Transactions:          []*types.Transaction{},
 		},
 	}, nil
+}
+
+func (c *Client) getBlockResult(blockIdentifier *types.PartialBlockIdentifier) (block *ctypes.ResultBlock, err error) {
+	switch {
+	case blockIdentifier == nil:
+		block, err = c.rpc.Block(nil)
+	case blockIdentifier.Index != nil:
+		block, err = c.rpc.Block(blockIdentifier.Index)
+	case blockIdentifier.Hash != nil:
+		hashBytes, decodeErr := hex.DecodeString(*blockIdentifier.Hash)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		block, err = c.rpc.BlockByHash(hashBytes)
+	}
+
+	return
 }

--- a/kava/client_test.go
+++ b/kava/client_test.go
@@ -765,4 +765,14 @@ func TestBlock(t *testing.T) {
 	assert.Equal(t, genesisBlockIdentifier, blockResponse.Block.ParentBlockIdentifier)
 	assert.Equal(t, genesisBlockTime.UnixNano()/int64(1e6), blockResponse.Block.Timestamp)
 	assert.Nil(t, blockResponse.OtherTransactions)
+
+	invalidHash := "invalid hash"
+	blockResponse, err = client.Block(
+		ctx,
+		&types.PartialBlockIdentifier{
+			Hash: &invalidHash,
+		},
+	)
+	assert.Nil(t, blockResponse)
+	assert.Contains(t, err.Error(), "invalid byte")
 }

--- a/kava/client_test.go
+++ b/kava/client_test.go
@@ -590,3 +590,18 @@ func TestBalance_CurrencyFilter(t *testing.T) {
 	assert.NotNil(t, getBalance(accountResponse.Balances, "HARD"))
 	assert.NotNil(t, getBalance(accountResponse.Balances, "USDX"))
 }
+
+func TestBlock(t *testing.T) {
+	ctx := context.Background()
+	mockRPCClient := &mocks.Client{}
+	client, err := NewClient(mockRPCClient)
+	require.NoError(t, err)
+
+	blockResponse, err := client.Block(
+		ctx,
+		&types.PartialBlockIdentifier{},
+	)
+
+	assert.Error(t, err)
+	assert.Nil(t, blockResponse)
+}

--- a/kava/client_test.go
+++ b/kava/client_test.go
@@ -657,6 +657,8 @@ func TestBlock(t *testing.T) {
 	blockResponse, err := client.Block(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, blockIdentifier, blockResponse.Block.BlockIdentifier)
+	assert.Equal(t, parentBlockIdentifier, blockResponse.Block.ParentBlockIdentifier)
+	assert.Equal(t, blockTime.UnixNano()/int64(1e6), blockResponse.Block.Timestamp)
 	assert.Nil(t, blockResponse.OtherTransactions)
 
 	mockRPCClient.On("Block", (*int64)(nil)).Return(
@@ -681,6 +683,8 @@ func TestBlock(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, blockIdentifier, blockResponse.Block.BlockIdentifier)
+	assert.Equal(t, parentBlockIdentifier, blockResponse.Block.ParentBlockIdentifier)
+	assert.Equal(t, blockTime.UnixNano()/int64(1e6), blockResponse.Block.Timestamp)
 	assert.Nil(t, blockResponse.OtherTransactions)
 
 	mockRPCClient.On("Block", &blockIdentifier.Index).Return(
@@ -710,6 +714,8 @@ func TestBlock(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, blockIdentifier, blockResponse.Block.BlockIdentifier)
+	assert.Equal(t, parentBlockIdentifier, blockResponse.Block.ParentBlockIdentifier)
+	assert.Equal(t, blockTime.UnixNano()/int64(1e6), blockResponse.Block.Timestamp)
 	assert.Nil(t, blockResponse.OtherTransactions)
 
 	mockRPCClient.On("BlockByHash", hashBytes).Return(
@@ -739,6 +745,8 @@ func TestBlock(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, genesisBlockIdentifier, blockResponse.Block.BlockIdentifier)
+	assert.Equal(t, genesisBlockIdentifier, blockResponse.Block.ParentBlockIdentifier)
+	assert.Equal(t, genesisBlockTime.UnixNano()/int64(1e6), blockResponse.Block.Timestamp)
 	assert.Nil(t, blockResponse.OtherTransactions)
 
 	mockRPCClient.On("BlockByHash", genesisHashBytes).Return(
@@ -754,5 +762,7 @@ func TestBlock(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, genesisBlockIdentifier, blockResponse.Block.BlockIdentifier)
+	assert.Equal(t, genesisBlockIdentifier, blockResponse.Block.ParentBlockIdentifier)
+	assert.Equal(t, genesisBlockTime.UnixNano()/int64(1e6), blockResponse.Block.Timestamp)
 	assert.Nil(t, blockResponse.OtherTransactions)
 }

--- a/mocks/services/client.go
+++ b/mocks/services/client.go
@@ -38,6 +38,29 @@ func (_m *Client) Balance(_a0 context.Context, _a1 *types.AccountIdentifier, _a2
 	return r0, r1
 }
 
+// Block provides a mock function with given fields: _a0, _a1
+func (_m *Client) Block(_a0 context.Context, _a1 *types.PartialBlockIdentifier) (*types.BlockResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *types.BlockResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *types.PartialBlockIdentifier) *types.BlockResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.BlockResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *types.PartialBlockIdentifier) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Status provides a mock function with given fields: _a0
 func (_m *Client) Status(_a0 context.Context) (*types.BlockIdentifier, int64, *types.BlockIdentifier, *types.SyncStatus, []*types.Peer, error) {
 	ret := _m.Called(_a0)

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -51,7 +51,12 @@ func (s *BlockAPIService) Block(
 		return nil, ErrUnavailableOffline
 	}
 
-	return nil, ErrUnimplemented
+	blockReponse, err := s.client.Block(ctx, request.BlockIdentifier)
+	if err != nil {
+		return nil, wrapErr(ErrKava, err)
+	}
+
+	return blockReponse, nil
 }
 
 // BlockTransaction implements the /block/transaction endpoint.

--- a/services/types.go
+++ b/services/types.go
@@ -41,4 +41,9 @@ type Client interface {
 		*types.PartialBlockIdentifier,
 		[]*types.Currency,
 	) (*types.AccountBalanceResponse, error)
+
+	Block(
+		context.Context,
+		*types.PartialBlockIdentifier,
+	) (*types.BlockResponse, error)
 }

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -160,33 +160,111 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /block:
+    post:
+      summary: Get a Block
+      description: |
+        Get a block by its Block Identifier. If transactions are returned in
+        the same call to the node as fetching the block, the response should
+        include these transactions in the Block object. If not, an array of
+        Transaction Identifiers should be returned so /block/transaction
+        fetches can be done to get all transaction information.
+
+        When requesting a block by the hash component of the BlockIdentifier,
+        this request MUST be idempotent: repeated invocations for the same
+        hash-identified block must return the exact same block contents.
+
+        No such restriction is imposed when requesting a block by height,
+        given that a chain reorg event might cause the specific block at
+        height `n` to be set to a different one.
+      operationId: block
+      tags:
+        - Block
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BlockRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     # Identifiers
-    AccountIdentifier:
-      $ref: 'models/AccountIdentifier.yaml'
     NetworkIdentifier:
       $ref: 'models/NetworkIdentifier.yaml'
+    SubNetworkIdentifier:
+      $ref: 'models/SubNetworkIdentifier.yaml'
     BlockIdentifier:
       $ref: 'models/BlockIdentifier.yaml'
     PartialBlockIdentifier:
       $ref: 'models/PartialBlockIdentifier.yaml'
+    TransactionIdentifier:
+      $ref: 'models/TransactionIdentifier.yaml'
+    OperationIdentifier:
+      $ref: 'models/OperationIdentifier.yaml'
+    AccountIdentifier:
+      $ref: 'models/AccountIdentifier.yaml'
+    SubAccountIdentifier:
+      $ref: 'models/SubAccountIdentifier.yaml'
 
     # Models
-    Allow:
-      $ref: 'models/Allow.yaml'
+    Block:
+      $ref: 'models/Block.yaml'
+    Transaction:
+      $ref: 'models/Transaction.yaml'
+    Operation:
+      $ref: 'models/Operation.yaml'
     Amount:
       $ref: 'models/Amount.yaml'
     Currency:
       $ref: 'models/Currency.yaml'
-    Version:
-      $ref: 'models/Version.yaml'
     SyncStatus:
       $ref: 'models/SyncStatus.yaml'
     Peer:
       $ref: 'models/Peer.yaml'
+    Version:
+      $ref: 'models/Version.yaml'
+    Allow:
+      $ref: 'models/Allow.yaml'
+    OperationStatus:
+      $ref: 'models/OperationStatus.yaml'
     Timestamp:
       $ref: 'models/Timestamp.yaml'
+    PublicKey:
+      $ref: 'models/PublicKey.yaml'
+    CurveType:
+      $ref: 'models/CurveType.yaml'
+    SigningPayload:
+      $ref: 'models/SigningPayload.yaml'
+    Signature:
+      $ref: 'models/Signature.yaml'
+    SignatureType:
+      $ref: 'models/SignatureType.yaml'
+    BalanceExemption:
+      $ref: 'models/BalanceExemption.yaml'
+    ExemptionType:
+      $ref: 'models/ExemptionType.yaml'
+    Operator:
+      $ref: 'models/Operator.yaml'
+    BlockTransaction:
+      $ref: 'models/BlockTransaction.yaml'
+    RelatedTransaction:
+      $ref: 'models/RelatedTransaction.yaml'
+    Direction:
+      $ref: 'models/Direction.yaml'
 
     # Request/Responses
     AccountBalanceRequest:
@@ -328,6 +406,48 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Peer'
+    BlockRequest:
+      description: |
+        A BlockRequest is utilized to make a block request on the
+        /block endpoint.
+      type: object
+      required:
+        - network_identifier
+        - block_identifier
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        block_identifier:
+          $ref: '#/components/schemas/PartialBlockIdentifier'
+    BlockResponse:
+      description: |
+        A BlockResponse includes a fully-populated block or a partially-populated
+        block with a list of other transactions to fetch (other_transactions).
+
+        As a result of the consensus algorithm of some blockchains, blocks
+        can be omitted (i.e. certain block indices can be skipped). If a query
+        for one of these omitted indices is made, the response should not include
+        a `Block` object.
+
+        It is VERY important to note that blocks MUST still form a canonical,
+        connected chain of blocks where each block has a unique index. In other words,
+        the `PartialBlockIdentifier` of a block after an omitted block should
+        reference the last non-omitted block.
+      type: object
+      properties:
+        block:
+          $ref: '#/components/schemas/Block'
+        other_transactions:
+          description: |
+            Some blockchains may require additional transactions to be fetched
+            that weren't returned in the block response
+            (ex: block only returns transaction hashes). For blockchains with a
+            lot of transactions in each block, this
+            can be very useful as consumers can concurrently fetch all
+            transactions returned.
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionIdentifier'
 
     # Miscellaneous
     Error:

--- a/swagger/models/Block.yaml
+++ b/swagger/models/Block.yaml
@@ -1,0 +1,49 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  Blocks contain an array of Transactions that
+  occurred at a particular BlockIdentifier.
+
+  A hard requirement for blocks returned by Rosetta
+  implementations is that they MUST be _inalterable_:
+  once a client has requested and received
+  a block identified by a specific BlockIndentifier,
+  all future calls for that same BlockIdentifier
+  must return the same block contents.
+type: object
+required:
+  - block_identifier
+  - parent_block_identifier
+  - timestamp
+  - transactions
+properties:
+  block_identifier:
+    $ref: 'BlockIdentifier.yaml'
+  parent_block_identifier:
+    $ref: 'BlockIdentifier.yaml'
+  timestamp:
+    $ref: 'Timestamp.yaml'
+  transactions:
+    type: array
+    items:
+      $ref: 'Transaction.yaml'
+  metadata:
+    type: object
+    example:
+      transactions_root: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+      difficulty: "123891724987128947"

--- a/swagger/models/BlockTransaction.yaml
+++ b/swagger/models/BlockTransaction.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  BlockTransaction contains a populated Transaction
+  and the BlockIdentifier that contains it.
+type: object
+required:
+  - block_identifier 
+  - transaction 
+properties:
+  block_identifier:
+    $ref: 'BlockIdentifier.yaml'
+  transaction:
+    $ref: 'Transaction.yaml'

--- a/swagger/models/CurveType.yaml
+++ b/swagger/models/CurveType.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  CurveType is the type of cryptographic curve associated with a PublicKey.
+
+  * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
+  * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
+  * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
+  * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)
+type: string
+enum:
+  - secp256k1
+  - secp256r1
+  - edwards25519
+  - tweedle

--- a/swagger/models/Direction.yaml
+++ b/swagger/models/Direction.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+description: |
+  Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may
+  reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if
+  a transaction relation is from child to parent or the reverse.
+type: string
+enum:
+  - forward
+  - backward

--- a/swagger/models/Operation.yaml
+++ b/swagger/models/Operation.yaml
@@ -1,0 +1,75 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  Operations contain all balance-changing information within a
+  transaction. They are always one-sided (only affect 1 AccountIdentifier)
+  and can succeed or fail independently from a Transaction.
+
+  Operations are used both to represent on-chain data (Data API) and to construct
+  new transactions (Construction API), creating a standard interface for reading
+  and writing to blockchains.
+type: object
+required:
+  - operation_identifier
+  - type
+properties:
+  operation_identifier:
+    $ref: 'OperationIdentifier.yaml'
+  related_operations:
+    description: |
+      Restrict referenced related_operations to identifier indices
+      < the current operation_identifier.index. This ensures there
+      exists a clear DAG-structure of relations.
+
+      Since operations are one-sided, one could imagine relating operations
+      in a single transfer or linking operations in a call tree.
+    type: array
+    items:
+      $ref: 'OperationIdentifier.yaml'
+    example:
+      - index: 1
+      - index: 2
+  type:
+    description: |
+      Type is the network-specific type of the operation. Ensure that any type that can be returned here is also
+      specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all
+      block data.
+    type: string
+    example: "Transfer"
+  status:
+    description: |
+      Status is the network-specific status of the operation. Status is not defined on the transaction object
+      because blockchains with smart contracts may have transactions that partially apply (some operations
+      are successful and some are not). Blockchains with atomic transactions (all operations succeed or
+      all operations fail) will have the same status for each operation.
+
+      On-chain operations (operations retrieved in the `/block` and `/block/transaction` endpoints) MUST have
+      a populated status field (anything on-chain must have succeeded or failed). However, operations provided
+      during transaction construction (often times called "intent" in the documentation) MUST NOT
+      have a populated status field (operations yet to be included on-chain have not yet succeeded or failed).
+    type: string
+    example: "Reverted"
+  account:
+    $ref: 'AccountIdentifier.yaml'
+  amount:
+    $ref: 'Amount.yaml'
+  metadata:
+    type: object
+    example:
+      asm: "304502201fd8abb11443f8b1b9a04e0495e0543d05611473a790c8939f089d073f90509a022100f4677825136605d732e2126d09a2d38c20c75946cd9fc239c0497e84c634e3dd01 03301a8259a12e35694cc22ebc45fee635f4993064190f6ce96e7fb19a03bb6be2"
+      hex: "48304502201fd8abb11443f8b1b9a04e0495e0543d05611473a790c8939f089d073f90509a022100f4677825136605d732e2126d09a2d38c20c75946cd9fc239c0497e84c634e3dd012103301a8259a12e35694cc22ebc45fee635f4993064190f6ce96e7fb19a03bb6be2"

--- a/swagger/models/OperationIdentifier.yaml
+++ b/swagger/models/OperationIdentifier.yaml
@@ -1,0 +1,45 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  The operation_identifier uniquely identifies an operation within a transaction.
+type: object
+required:
+  - index
+properties:
+  index:
+    description: |
+      The operation index is used to ensure each operation has a unique identifier within
+      a transaction. This index is only relative to the transaction and NOT GLOBAL. The
+      operations in each transaction should start from index 0.
+
+      To clarify, there may not be any notion of an operation index in the blockchain being described.
+    type: integer
+    format: int64
+    minimum: 0
+    example: 5
+  network_index:
+    description: |
+      Some blockchains specify an operation index that is essential for client use. For example,
+      Bitcoin uses a network_index to identify which UTXO was used in a transaction.
+
+      network_index should not be populated if there is no notion of an operation index in a
+      blockchain (typically most account-based blockchains).
+    type: integer
+    format: int64
+    minimum: 0
+    example: 0

--- a/swagger/models/Operator.yaml
+++ b/swagger/models/Operator.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  Operator is used by query-related endpoints
+  to determine how to apply conditions.
+
+  If this field is not populated, the default
+  `and` value will be used.
+type: string
+enum:
+  - or
+  - and

--- a/swagger/models/PublicKey.yaml
+++ b/swagger/models/PublicKey.yaml
@@ -1,0 +1,35 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  PublicKey contains a public key byte array
+  for a particular CurveType encoded in hex.
+
+  Note that there is no PrivateKey struct as this
+  is NEVER the concern of an implementation.
+type: object 
+required:
+  - hex_bytes
+  - curve_type
+properties:
+  hex_bytes:
+    type: string
+    description: |
+      Hex-encoded public key bytes in the format
+      specified by the CurveType.
+  curve_type:
+    $ref: "CurveType.yaml"

--- a/swagger/models/RelatedTransaction.yaml
+++ b/swagger/models/RelatedTransaction.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  The related_transaction allows implementations to link together multiple transactions.
+  An unpopulated network identifier indicates that the related transaction is on the same network.
+type: object
+required:
+  - transaction_identifier
+  - direction
+properties:
+  network_identifier:
+    $ref: 'NetworkIdentifier.yaml'
+  transaction_identifier:
+    $ref: 'TransactionIdentifier.yaml'
+  direction:
+    $ref: 'Direction.yaml'

--- a/swagger/models/Signature.yaml
+++ b/swagger/models/Signature.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  Signature contains the payload that was signed, the public keys of the
+  keypairs used to produce the signature, the signature (encoded in hex),
+  and the SignatureType.
+
+  PublicKey is often times not known during construction of the signing payloads
+  but may be needed to combine signatures properly.
+type: object
+required:
+  - signing_payload
+  - public_key
+  - signature_type
+  - hex_bytes
+properties:
+  signing_payload:
+    $ref: "SigningPayload.yaml"
+  public_key:
+    $ref: "PublicKey.yaml"
+  signature_type:
+    $ref: "SignatureType.yaml"
+  hex_bytes:
+    type: string

--- a/swagger/models/SignatureType.yaml
+++ b/swagger/models/SignatureType.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  SignatureType is the type of a cryptographic signature.
+
+  * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes`
+  * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes`
+  * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
+  * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.)
+  * schnorr_poseidon: `r (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars encoded as `32-bytes` values, least significant byte first. https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml )
+type: string
+enum:
+  - ecdsa
+  - ecdsa_recovery
+  - ed25519
+  - schnorr_1
+  - schnorr_poseidon

--- a/swagger/models/SigningPayload.yaml
+++ b/swagger/models/SigningPayload.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  SigningPayload is signed by the client with the keypair associated
+  with an AccountIdentifier using the specified SignatureType.
+
+  SignatureType can be optionally populated if there is
+  a restriction on the signature scheme that can be
+  used to sign the payload.
+type: object
+required:
+  - hex_bytes
+properties:
+  address:
+    type: string
+    description: |
+      [DEPRECATED by `account_identifier` in `v1.4.4`] The network-specific address of the account that should sign
+      the payload.
+  account_identifier:
+    $ref: 'AccountIdentifier.yaml'
+  hex_bytes:
+    type: string
+  signature_type:
+    $ref: "SignatureType.yaml"

--- a/swagger/models/SubNetworkIdentifier.yaml
+++ b/swagger/models/SubNetworkIdentifier.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  In blockchains with sharded state, the SubNetworkIdentifier
+  is required to query some object on a specific shard. This identifier is
+  optional for all non-sharded blockchains.
+type: object
+required:
+  - network 
+properties:
+  network:
+    type: string
+    example: "shard 1"
+  metadata:
+    type: object
+    example:
+      producer: "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"

--- a/swagger/models/Transaction.yaml
+++ b/swagger/models/Transaction.yaml
@@ -1,0 +1,43 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  Transactions contain an array of Operations
+  that are attributable to the same TransactionIdentifier.
+type: object
+required:
+  - transaction_identifier
+  - operations
+properties:
+  transaction_identifier:
+    $ref: 'TransactionIdentifier.yaml'
+  operations:
+    type: array
+    items:
+      $ref: 'Operation.yaml'
+  related_transactions:
+    type: array
+    items:
+      $ref: 'RelatedTransaction.yaml'
+  metadata:
+    description: |
+      Transactions that are related to other transactions (like a cross-shard transaction) should include
+      the tranaction_identifier of these transactions in the metadata.
+    type: object
+    example:
+      size: 12378
+      lockTime: 1582272577

--- a/swagger/models/TransactionIdentifier.yaml
+++ b/swagger/models/TransactionIdentifier.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Kava Labs, Inc.
+# Copyright 2020 Coinbase, Inc.
+#
+# Derived from github.com/coinbase/rosetta-specifications@c820407
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  The transaction_identifier uniquely identifies a transaction in a particular network and block
+  or in the mempool.
+type: object
+required:
+  - hash
+properties:
+  hash:
+    description: |
+      Any transactions that are attributable only to a block (ex: a block event)
+      should use the hash of the block as the identifier.
+    type: string
+    example: "0x2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f"

--- a/testing/block_test.go
+++ b/testing/block_test.go
@@ -1,0 +1,119 @@
+// +build integration
+// Copyright 2021 Kava Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kava-labs/rosetta-kava/kava"
+
+	"github.com/coinbase/rosetta-sdk-go/asserter"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockOffline(t *testing.T) {
+	if config.Mode.String() == "online" {
+		t.Skip("skipping block offline test")
+	}
+
+	ctx := context.Background()
+
+	blockIndex := int64(1)
+	request := &types.BlockRequest{
+		NetworkIdentifier: config.NetworkIdentifier,
+		BlockIdentifier: &types.PartialBlockIdentifier{
+			Index: &blockIndex,
+		},
+	}
+
+	_, rosettaErr, err := client.BlockAPI.Block(ctx, request)
+	require.Error(t, err)
+	require.NotNil(t, rosettaErr)
+
+	err = asserter.Error(rosettaErr)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), rosettaErr.Code)
+	assert.Equal(t, "Endpoint unavailable offline", rosettaErr.Message)
+}
+
+func TestBlockOnline(t *testing.T) {
+	if config.Mode.String() == "offline" {
+		t.Skip("skipping block online test")
+	}
+
+	ctx := context.Background()
+
+	asserter, err := asserter.NewServer(
+		kava.OperationTypes,
+		kava.HistoricalBalanceSupported,
+		[]*types.NetworkIdentifier{config.NetworkIdentifier},
+		kava.CallMethods,
+		kava.IncludeMempoolCoins,
+	)
+	require.NoError(t, err)
+
+	networkStatus, rosettaErr, err := client.NetworkAPI.NetworkStatus(
+		ctx,
+		&types.NetworkRequest{
+			NetworkIdentifier: config.NetworkIdentifier,
+		})
+	require.NoError(t, err)
+	require.Nil(t, rosettaErr)
+
+	resultBlock, err := rpc.Block(networkStatus.CurrentBlockIdentifier.Index)
+	require.NoError(t, err)
+
+	currentBlock := networkStatus.CurrentBlockIdentifier
+	request := &types.BlockRequest{
+		NetworkIdentifier: config.NetworkIdentifier,
+		BlockIdentifier: &types.PartialBlockIdentifier{
+			Index: &resultBlock.Block.Header.Height,
+		},
+	}
+
+	blockResponseByIndex, rosettaErr, err := client.BlockAPI.Block(ctx, request)
+	require.NoError(t, err)
+	require.Nil(t, rosettaErr)
+
+	err = asserter.Block(blockResponseByIndex.Block)
+	assert.NoError(t, err)
+
+	assert.Equal(t, &resultBlock.Block.Header.Height, blockResponseByIndex.Block.BlockIdentifier.Index)
+	assert.Equal(t, resultBlock.BlockID.Hash.String(), blockResponseByIndex.Block.BlockIdentifier.Hash)
+
+	request = &types.BlockRequest{
+		NetworkIdentifier: config.NetworkIdentifier,
+		BlockIdentifier: &types.PartialBlockIdentifier{
+			Hash: &currentBlock.Hash,
+		},
+	}
+
+	blockResponseByHash, rosettaErr, err := client.BlockAPI.Block(ctx, request)
+	require.NoError(t, err)
+	require.Nil(t, rosettaErr)
+
+	err = asserter.Block(blockResponseByHash.Block)
+	assert.NoError(t, err)
+
+	assert.Equal(t, &resultBlock.Block.Header.Height, blockResponseByHash.Block.BlockIdentifier.Index)
+	assert.Equal(t, resultBlock.BlockID.Hash.String(), blockResponseByHash.Block.BlockIdentifier.Hash)
+
+	assert.Equal(t, blockResponseByHash, blockResponseByIndex)
+}

--- a/testing/block_test.go
+++ b/testing/block_test.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kava-labs/rosetta-kava/kava"
-
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
@@ -60,22 +58,28 @@ func TestBlockOnline(t *testing.T) {
 
 	ctx := context.Background()
 
-	asserter, err := asserter.NewServer(
-		kava.OperationTypes,
-		kava.HistoricalBalanceSupported,
-		[]*types.NetworkIdentifier{config.NetworkIdentifier},
-		kava.CallMethods,
-		kava.IncludeMempoolCoins,
-	)
-	require.NoError(t, err)
-
 	networkStatus, rosettaErr, err := client.NetworkAPI.NetworkStatus(
 		ctx,
 		&types.NetworkRequest{
 			NetworkIdentifier: config.NetworkIdentifier,
 		})
-	require.NoError(t, err)
 	require.Nil(t, rosettaErr)
+	require.NoError(t, err)
+
+	networkOptions, rosettaErr, err := client.NetworkAPI.NetworkOptions(
+		ctx,
+		&types.NetworkRequest{
+			NetworkIdentifier: config.NetworkIdentifier,
+		})
+	require.Nil(t, rosettaErr)
+	require.NoError(t, err)
+
+	asserter, err := asserter.NewClientWithResponses(
+		config.NetworkIdentifier,
+		networkStatus,
+		networkOptions,
+	)
+	require.NoError(t, err)
 
 	resultBlock, err := rpc.Block(&networkStatus.CurrentBlockIdentifier.Index)
 	require.NoError(t, err)

--- a/testing/block_test.go
+++ b/testing/block_test.go
@@ -95,7 +95,7 @@ func TestBlockOnline(t *testing.T) {
 	err = asserter.Block(blockResponseByIndex.Block)
 	assert.NoError(t, err)
 
-	assert.Equal(t, &resultBlock.Block.Header.Height, blockResponseByIndex.Block.BlockIdentifier.Index)
+	assert.Equal(t, resultBlock.Block.Header.Height, blockResponseByIndex.Block.BlockIdentifier.Index)
 	assert.Equal(t, resultBlock.BlockID.Hash.String(), blockResponseByIndex.Block.BlockIdentifier.Hash)
 
 	request = &types.BlockRequest{
@@ -112,7 +112,7 @@ func TestBlockOnline(t *testing.T) {
 	err = asserter.Block(blockResponseByHash.Block)
 	assert.NoError(t, err)
 
-	assert.Equal(t, &resultBlock.Block.Header.Height, blockResponseByHash.Block.BlockIdentifier.Index)
+	assert.Equal(t, resultBlock.Block.Header.Height, blockResponseByHash.Block.BlockIdentifier.Index)
 	assert.Equal(t, resultBlock.BlockID.Hash.String(), blockResponseByHash.Block.BlockIdentifier.Hash)
 
 	assert.Equal(t, blockResponseByHash, blockResponseByIndex)

--- a/testing/block_test.go
+++ b/testing/block_test.go
@@ -97,6 +97,7 @@ func TestBlockOnline(t *testing.T) {
 
 	assert.Equal(t, resultBlock.Block.Header.Height, blockResponseByIndex.Block.BlockIdentifier.Index)
 	assert.Equal(t, resultBlock.BlockID.Hash.String(), blockResponseByIndex.Block.BlockIdentifier.Hash)
+	assert.Equal(t, resultBlock.Block.Header.Time.UnixNano()/int64(1e6), blockResponseByIndex.Block.Timestamp)
 
 	request = &types.BlockRequest{
 		NetworkIdentifier: config.NetworkIdentifier,
@@ -114,6 +115,29 @@ func TestBlockOnline(t *testing.T) {
 
 	assert.Equal(t, resultBlock.Block.Header.Height, blockResponseByHash.Block.BlockIdentifier.Index)
 	assert.Equal(t, resultBlock.BlockID.Hash.String(), blockResponseByHash.Block.BlockIdentifier.Hash)
+	assert.Equal(t, resultBlock.Block.Header.Time.UnixNano()/int64(1e6), blockResponseByIndex.Block.Timestamp)
 
 	assert.Equal(t, blockResponseByHash, blockResponseByIndex)
+
+	genesisBlockHeight := int64(1)
+	genesisResultBlock, err := rpc.Block(&genesisBlockHeight)
+	require.NoError(t, err)
+
+	genesisRequest := &types.BlockRequest{
+		NetworkIdentifier: config.NetworkIdentifier,
+		BlockIdentifier: &types.PartialBlockIdentifier{
+			Index: &genesisBlockHeight,
+		},
+	}
+
+	genesisBlockResponse, rosettaErr, err := client.BlockAPI.Block(ctx, genesisRequest)
+	require.NoError(t, err)
+	require.Nil(t, rosettaErr)
+
+	err = asserter.Block(genesisBlockResponse.Block)
+	assert.NoError(t, err)
+
+	assert.Equal(t, genesisResultBlock.Block.Header.Height, genesisBlockResponse.Block.BlockIdentifier.Index)
+	assert.Equal(t, genesisResultBlock.BlockID.Hash.String(), genesisBlockResponse.Block.BlockIdentifier.Hash)
+	assert.Equal(t, genesisResultBlock.Block.Header.Time.UnixNano()/int64(1e6), genesisBlockResponse.Block.Timestamp)
 }

--- a/testing/block_test.go
+++ b/testing/block_test.go
@@ -77,7 +77,7 @@ func TestBlockOnline(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, rosettaErr)
 
-	resultBlock, err := rpc.Block(networkStatus.CurrentBlockIdentifier.Index)
+	resultBlock, err := rpc.Block(&networkStatus.CurrentBlockIdentifier.Index)
 	require.NoError(t, err)
 
 	currentBlock := networkStatus.CurrentBlockIdentifier


### PR DESCRIPTION
Adds the block endpoint.  Transactions are not yet returned, but all other required block data is.

Blocks can be queried by index or by height, and the genesis block sets it's parent to itself according to Rosetta requirements.

Request via index:
```
curl -X 'POST' \
  'http://localhost:8000/block' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "network_identifier": {
    "blockchain": "Kava",
    "network": "kava-7"
  },
  "block_identifier": {
    "index": 100
  }
}'
```

Request via hash:
```
curl -X 'POST' \
  'http://localhost:8000/block' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "network_identifier": {
    "blockchain": "Kava",
    "network": "kava-7"
  },
  "block_identifier": {
    "hash": "D92BDF0B5EDB04434B398A59B2FD4ED3D52B4820A18DAC7311EBDF5D37467E75"
  }
}'
```

Response (it's the same block in both request examples):
```
{
  "block": {
    "block_identifier": {
      "index": 100,
      "hash": "D92BDF0B5EDB04434B398A59B2FD4ED3D52B4820A18DAC7311EBDF5D37467E75"
    },
    "parent_block_identifier": {
      "index": 99,
      "hash": "8EA67B6F7927DB941F86501D1757AC6804C1D21B7A75B9DA3F16A3C81C397E50"
    },
    "timestamp": 1617894805837,
    "transactions": []
  }
}
```