### PR TITLE
Add Preprocess Endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ watch:
 
 .PHONY: watch-integration
 watch-integration:
-	while sleep 0.5; do find . -type f -name '*.go' | entr -d go test -tags=integration ./testing; done
+	while sleep 0.5; do find . -type f -name '*.go' | entr -d go test -tags=integration -count=1 ./testing; done
 
 .PHONY: rosetta-check-data
 rosetta-check-data:

--- a/services/construction_preprocess.go
+++ b/services/construction_preprocess.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kava-labs/rosetta-kava/kava"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -38,58 +39,77 @@ func (s *ConstructionAPIService) ConstructionPreprocess(
 		return nil, ErrNoOperations
 	}
 
-	options := make(map[string]interface{})
-
-	var suggestedFeeMultiplier float64
-	if request.SuggestedFeeMultiplier == nil {
-		suggestedFeeMultiplier = defaultSuggestedFeeMultiplier
-	} else {
-		suggestedFeeMultiplier = *request.SuggestedFeeMultiplier
+	encodedMaxFee, err := getMaxFeeAndEncodeOption(request.MaxFee, s.cdc)
+	if err != nil {
+		return nil, err
 	}
-	options["suggested_fee_multiplier"] = suggestedFeeMultiplier
 
-	var memo string
-	if rawMemo, exists := request.Metadata["memo"]; exists {
-		if parsedMemo, ok := rawMemo.(string); ok {
-			memo = parsedMemo
-		}
+	options := map[string]interface{}{
+		"suggested_fee_multiplier": suggestedMultiplerOrDefault(request.SuggestedFeeMultiplier),
+		"memo":                     getMemoFromMetadata(request.Metadata),
 	}
-	options["memo"] = memo
-
-	if request.MaxFee != nil {
-		var maxFee sdk.Coins
-		for _, feeAmount := range request.MaxFee {
-			value, ok := sdk.NewIntFromString(feeAmount.Value)
-			if !ok {
-				return nil, ErrInvalidCurrencyAmount
-			}
-
-			denom, ok := kava.Denoms[feeAmount.Currency.Symbol]
-			if !ok {
-				return nil, ErrUnsupportedCurrency
-			}
-
-			currency, ok := kava.Currencies[denom]
-			if !ok {
-				return nil, ErrUnsupportedCurrency
-			}
-
-			if currency.Symbol != feeAmount.Currency.Symbol ||
-				currency.Decimals != feeAmount.Currency.Decimals {
-				return nil, ErrUnsupportedCurrency
-			}
-
-			maxFee = maxFee.Add(sdk.NewCoin(denom, value))
-		}
-
-		encodedMaxFee, err := s.cdc.MarshalJSON(maxFee)
-		if err != nil {
-			return nil, wrapErr(ErrKava, err)
-		}
-		options["max_fee"] = string(encodedMaxFee)
+	if encodedMaxFee != nil {
+		options["max_fee"] = *encodedMaxFee
 	}
 
 	return &types.ConstructionPreprocessResponse{
 		Options: options,
 	}, nil
+}
+
+func suggestedMultiplerOrDefault(multiplier *float64) float64 {
+	if multiplier == nil {
+		return defaultSuggestedFeeMultiplier
+	}
+
+	return *multiplier
+}
+
+func getMemoFromMetadata(metadata map[string]interface{}) string {
+	if rawMemo, exists := metadata["memo"]; exists {
+		if memo, ok := rawMemo.(string); ok {
+			return memo
+		}
+	}
+
+	return ""
+}
+
+func getMaxFeeAndEncodeOption(amounts []*types.Amount, cdc *codec.Codec) (*string, *types.Error) {
+	if len(amounts) == 0 {
+		return nil, nil
+	}
+
+	var maxFee sdk.Coins
+	for _, feeAmount := range amounts {
+		value, ok := sdk.NewIntFromString(feeAmount.Value)
+		if !ok {
+			return nil, ErrInvalidCurrencyAmount
+		}
+
+		denom, ok := kava.Denoms[feeAmount.Currency.Symbol]
+		if !ok {
+			return nil, ErrUnsupportedCurrency
+		}
+
+		currency, ok := kava.Currencies[denom]
+		if !ok {
+			return nil, ErrUnsupportedCurrency
+		}
+
+		if currency.Symbol != feeAmount.Currency.Symbol ||
+			currency.Decimals != feeAmount.Currency.Decimals {
+			return nil, ErrUnsupportedCurrency
+		}
+
+		maxFee = maxFee.Add(sdk.NewCoin(denom, value))
+	}
+
+	b, err := cdc.MarshalJSON(maxFee)
+	if err != nil {
+		return nil, wrapErr(ErrKava, err)
+	}
+
+	encodedMaxFee := string(b)
+	return &encodedMaxFee, nil
 }

--- a/services/construction_preprocess.go
+++ b/services/construction_preprocess.go
@@ -73,8 +73,27 @@ func (s *ConstructionAPIService) ConstructionPreprocess(
 		options["max_fee"] = *encodedMaxFee
 	}
 
+	requiredPublicKeys := []*types.AccountIdentifier{}
+
+	for _, msg := range msgs {
+		signers := msg.GetSigners()
+
+		seenSigners := make(map[string]bool)
+
+		for _, signer := range signers {
+			_, seen := seenSigners[signer.String()]
+
+			if !seen {
+				requiredPublicKeys = append(requiredPublicKeys, &types.AccountIdentifier{
+					Address: signer.String(),
+				})
+			}
+		}
+	}
+
 	return &types.ConstructionPreprocessResponse{
-		Options: options,
+		Options:            options,
+		RequiredPublicKeys: requiredPublicKeys,
 	}, nil
 }
 

--- a/services/construction_preprocess.go
+++ b/services/construction_preprocess.go
@@ -66,6 +66,7 @@ func (s *ConstructionAPIService) ConstructionPreprocess(
 
 	options := map[string]interface{}{
 		"msgs":                     string(encodedMsgs),
+		"gas_adjustment":           getGasAdjustmentFromMetadata(request.Metadata),
 		"suggested_fee_multiplier": suggestedMultiplerOrDefault(request.SuggestedFeeMultiplier),
 		"memo":                     getMemoFromMetadata(request.Metadata),
 	}
@@ -162,6 +163,16 @@ func getMemoFromMetadata(metadata map[string]interface{}) string {
 	}
 
 	return ""
+}
+
+func getGasAdjustmentFromMetadata(metadata map[string]interface{}) float64 {
+	if rawAdjustment, exists := metadata["gas_adjustment"]; exists {
+		if adjustment, ok := rawAdjustment.(float64); ok {
+			return adjustment
+		}
+	}
+
+	return float64(0)
 }
 
 func getMaxFeeAndEncodeOption(amounts []*types.Amount, cdc *codec.Codec) (*string, *types.Error) {

--- a/services/construction_preprocess.go
+++ b/services/construction_preprocess.go
@@ -41,6 +41,14 @@ func (s *ConstructionAPIService) ConstructionPreprocess(
 		return nil, ErrNoOperations
 	}
 
+	// TODO: improve operation parsing -- very basic for first pass
+	//
+	// currently, only supports a single transfer with one currency
+	// should support multiple transfers, multiple currencies, and
+	// staking operations
+	//
+	// in addition, parsing logic needs to be refactored with improved
+	// testing around invalid cases, and related operations
 	msgs, rerr := parseOperationMsgs(request.Operations)
 	if rerr != nil {
 		return nil, rerr

--- a/services/construction_preprocess.go
+++ b/services/construction_preprocess.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Kava Labs, Inc.
+// Copyright 2020 Coinbase, Inc.
+//
+// Derived from github.com/coinbase/rosetta-ethereum@f81889b
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+var defaultSuggestedFeeMultiplier = float64(1)
+
+// ConstructionPreprocess implements the /construction/preprocess
+// endpoint.
+func (s *ConstructionAPIService) ConstructionPreprocess(
+	ctx context.Context,
+	request *types.ConstructionPreprocessRequest,
+) (*types.ConstructionPreprocessResponse, *types.Error) {
+	if len(request.Operations) == 0 {
+		return nil, ErrNoOperations
+	}
+
+	if request.SuggestedFeeMultiplier == nil {
+		request.SuggestedFeeMultiplier = &defaultSuggestedFeeMultiplier
+	}
+
+	var memo string
+	if rawMemo, exists := request.Metadata["memo"]; exists {
+		if parsedMemo, ok := rawMemo.(string); ok {
+			memo = parsedMemo
+		}
+	}
+
+	return &types.ConstructionPreprocessResponse{
+		Options: map[string]interface{}{
+			"suggested_fee_multiplier": *request.SuggestedFeeMultiplier,
+			"memo":                     memo,
+		},
+	}, nil
+}

--- a/services/construction_preprocess.go
+++ b/services/construction_preprocess.go
@@ -30,7 +30,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
 )
 
-const defaultSuggestedFeeMultiplier = float64(1)
+const (
+	defaultSuggestedFeeMultiplier = float64(1)
+	defaultGasAdjustment          = float64(0.1)
+)
 
 // ConstructionPreprocess implements the /construction/preprocess endpoint.
 func (s *ConstructionAPIService) ConstructionPreprocess(
@@ -172,7 +175,7 @@ func getGasAdjustmentFromMetadata(metadata map[string]interface{}) float64 {
 		}
 	}
 
-	return float64(0)
+	return defaultGasAdjustment
 }
 
 func getMaxFeeAndEncodeOption(amounts []*types.Amount, cdc *codec.Codec) (*string, *types.Error) {

--- a/services/construction_preprocess_test.go
+++ b/services/construction_preprocess_test.go
@@ -407,7 +407,7 @@ func TestConstructionPreprocess_GasAdjustment(t *testing.T) {
 	}{
 		{
 			gasAdjustment:         nil,
-			expectedGasAdjustment: 0,
+			expectedGasAdjustment: 0.1,
 		},
 		{
 			gasAdjustment:         float64ToPtr(0.0000001),

--- a/services/construction_preprocess_test.go
+++ b/services/construction_preprocess_test.go
@@ -394,4 +394,6 @@ func TestConstructionPreprocess_TransferOperations(t *testing.T) {
 	}
 
 	assert.Equal(t, expectedMsgs, msgs)
+	require.Equal(t, 1, len(response.RequiredPublicKeys))
+	assert.Equal(t, "kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea", response.RequiredPublicKeys[0].Address)
 }

--- a/services/construction_preprocess_test.go
+++ b/services/construction_preprocess_test.go
@@ -1,0 +1,184 @@
+// Copyright 2021 Kava Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kava-labs/rosetta-kava/configuration"
+	"github.com/kava-labs/rosetta-kava/kava"
+	mocks "github.com/kava-labs/rosetta-kava/mocks/services"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupServicer() *ConstructionAPIService {
+	cfg := &configuration.Configuration{
+		Mode: configuration.Offline,
+	}
+	mockClient := &mocks.Client{}
+	return NewConstructionAPIService(cfg, mockClient)
+}
+
+func float64ToPtr(value float64) *float64 {
+	return &value
+}
+
+func strToPtr(value string) *string {
+	return &value
+}
+
+func validRequest() *types.ConstructionPreprocessRequest {
+	defaultOps := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 0},
+			Type:                kava.TransferOpType,
+			Account:             &types.AccountIdentifier{Address: "kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea"},
+			Amount:              &types.Amount{Value: "-5000000", Currency: &types.Currency{Symbol: "KAVA", Decimals: 6}},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 1},
+			RelatedOperations:   []*types.OperationIdentifier{{Index: 0}},
+			Type:                kava.TransferOpType,
+			Account:             &types.AccountIdentifier{Address: "kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w"},
+			Amount:              &types.Amount{Value: "5000000", Currency: &types.Currency{Symbol: "KAVA", Decimals: 6}},
+		},
+	}
+
+	return &types.ConstructionPreprocessRequest{
+		Operations: defaultOps,
+		Metadata:   make(map[string]interface{}),
+	}
+}
+
+func TestConstructionPreprocess_NoOperations(t *testing.T) {
+	servicer := setupServicer()
+
+	ctx := context.Background()
+	response, err := servicer.ConstructionPreprocess(ctx,
+		&types.ConstructionPreprocessRequest{},
+	)
+	assert.Nil(t, response)
+	require.NotNil(t, err)
+
+	assert.Equal(t, ErrNoOperations, err)
+
+	ctx = context.Background()
+	response, err = servicer.ConstructionPreprocess(ctx,
+		&types.ConstructionPreprocessRequest{
+			Operations: []*types.Operation{},
+		},
+	)
+	assert.Nil(t, response)
+	require.NotNil(t, err)
+
+	assert.Equal(t, ErrNoOperations, err)
+}
+
+func TestConstructionPreprocess_SuggestedFeeMultiplier(t *testing.T) {
+	servicer := setupServicer()
+
+	testCases := []struct {
+		suggestedFeeMultiplier *float64
+		expectedFeeMultiplier  float64
+	}{
+		{
+			suggestedFeeMultiplier: nil,
+			expectedFeeMultiplier:  1,
+		},
+		{
+			suggestedFeeMultiplier: float64ToPtr(0.0000001),
+			expectedFeeMultiplier:  0.0000001,
+		},
+		{
+			suggestedFeeMultiplier: float64ToPtr(0.55),
+			expectedFeeMultiplier:  0.55,
+		},
+		{
+			suggestedFeeMultiplier: float64ToPtr(1),
+			expectedFeeMultiplier:  1,
+		},
+		{
+			suggestedFeeMultiplier: float64ToPtr(2),
+			expectedFeeMultiplier:  2,
+		},
+		{
+			suggestedFeeMultiplier: float64ToPtr(10),
+			expectedFeeMultiplier:  10,
+		},
+	}
+
+	for _, tc := range testCases {
+		ctx := context.Background()
+		request := validRequest()
+
+		request.SuggestedFeeMultiplier = tc.suggestedFeeMultiplier
+
+		response, err := servicer.ConstructionPreprocess(ctx, request)
+		require.Nil(t, err)
+
+		actualMutliplier, ok := response.Options["suggested_fee_multiplier"].(float64)
+		require.True(t, ok)
+
+		assert.InDelta(t, tc.expectedFeeMultiplier, actualMutliplier, 0.0000001)
+	}
+}
+
+func TestConstructionPreprocess_Memo(t *testing.T) {
+	servicer := setupServicer()
+
+	testCases := []struct {
+		memo *string
+	}{
+		{
+			memo: nil,
+		},
+		{
+			memo: strToPtr(""),
+		},
+		{
+			memo: strToPtr("some memo for tx"),
+		},
+		{
+			memo: strToPtr("a memo that is pretty long, longer than most memos"),
+		},
+	}
+
+	for _, tc := range testCases {
+		ctx := context.Background()
+		request := validRequest()
+
+		if tc.memo != nil {
+			request.Metadata["memo"] = *tc.memo
+		}
+
+		response, err := servicer.ConstructionPreprocess(ctx, request)
+		require.Nil(t, err)
+
+		actualMemo, ok := response.Options["memo"].(string)
+		require.True(t, ok)
+
+		var expectedMemo string
+		if tc.memo != nil {
+			expectedMemo = *tc.memo
+		} else {
+			expectedMemo = ""
+		}
+		assert.Equal(t, expectedMemo, actualMemo)
+	}
+}

--- a/services/construction_preprocess_test.go
+++ b/services/construction_preprocess_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupServicer() *ConstructionAPIService {
+func setupContructionAPIServicer() *ConstructionAPIService {
 	cfg := &configuration.Configuration{
 		Mode: configuration.Offline,
 	}
@@ -43,7 +43,7 @@ func strToPtr(value string) *string {
 	return &value
 }
 
-func validRequest() *types.ConstructionPreprocessRequest {
+func validConstructionPreprocessRequest() *types.ConstructionPreprocessRequest {
 	defaultOps := []*types.Operation{
 		{
 			OperationIdentifier: &types.OperationIdentifier{Index: 0},
@@ -67,7 +67,7 @@ func validRequest() *types.ConstructionPreprocessRequest {
 }
 
 func TestConstructionPreprocess_NoOperations(t *testing.T) {
-	servicer := setupServicer()
+	servicer := setupContructionAPIServicer()
 
 	ctx := context.Background()
 	response, err := servicer.ConstructionPreprocess(ctx,
@@ -91,7 +91,7 @@ func TestConstructionPreprocess_NoOperations(t *testing.T) {
 }
 
 func TestConstructionPreprocess_SuggestedFeeMultiplier(t *testing.T) {
-	servicer := setupServicer()
+	servicer := setupContructionAPIServicer()
 
 	testCases := []struct {
 		suggestedFeeMultiplier *float64
@@ -125,7 +125,7 @@ func TestConstructionPreprocess_SuggestedFeeMultiplier(t *testing.T) {
 
 	for _, tc := range testCases {
 		ctx := context.Background()
-		request := validRequest()
+		request := validConstructionPreprocessRequest()
 
 		request.SuggestedFeeMultiplier = tc.suggestedFeeMultiplier
 
@@ -140,7 +140,7 @@ func TestConstructionPreprocess_SuggestedFeeMultiplier(t *testing.T) {
 }
 
 func TestConstructionPreprocess_Memo(t *testing.T) {
-	servicer := setupServicer()
+	servicer := setupContructionAPIServicer()
 
 	testCases := []struct {
 		memo *string
@@ -161,7 +161,7 @@ func TestConstructionPreprocess_Memo(t *testing.T) {
 
 	for _, tc := range testCases {
 		ctx := context.Background()
-		request := validRequest()
+		request := validConstructionPreprocessRequest()
 
 		if tc.memo != nil {
 			request.Metadata["memo"] = *tc.memo

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -23,22 +23,26 @@ import (
 	"github.com/kava-labs/rosetta-kava/configuration"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // ConstructionAPIService implements the server.ConstructionAPIServicer interface.
 type ConstructionAPIService struct {
 	config *configuration.Configuration
 	client Client
+	cdc    *codec.Codec
 }
 
 // NewConstructionAPIService creates a new instance of a ConstructionAPIService.
 func NewConstructionAPIService(
 	cfg *configuration.Configuration,
 	client Client,
+	cdc *codec.Codec,
 ) *ConstructionAPIService {
 	return &ConstructionAPIService{
 		config: cfg,
 		client: client,
+		cdc:    cdc,
 	}
 }
 

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -50,15 +50,6 @@ func (s *ConstructionAPIService) ConstructionDerive(
 	return nil, ErrUnimplemented
 }
 
-// ConstructionPreprocess implements the /construction/preprocess
-// endpoint.
-func (s *ConstructionAPIService) ConstructionPreprocess(
-	ctx context.Context,
-	request *types.ConstructionPreprocessRequest,
-) (*types.ConstructionPreprocessResponse, *types.Error) {
-	return nil, ErrUnimplemented
-}
-
 // ConstructionMetadata implements the /construction/metadata endpoint.
 func (s *ConstructionAPIService) ConstructionMetadata(
 	ctx context.Context,

--- a/services/construction_service_test.go
+++ b/services/construction_service_test.go
@@ -25,6 +25,7 @@ import (
 	mocks "github.com/kava-labs/rosetta-kava/mocks/services"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/kava-labs/kava/app"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,7 +35,8 @@ func TestConstructionService_Online(t *testing.T) {
 	}
 
 	mockClient := &mocks.Client{}
-	servicer := NewConstructionAPIService(cfg, mockClient)
+	cdc := app.MakeCodec()
+	servicer := NewConstructionAPIService(cfg, mockClient, cdc)
 	ctx := context.Background()
 
 	// Test Derive
@@ -94,7 +96,8 @@ func TestConstructionService_Offline(t *testing.T) {
 	}
 
 	mockClient := &mocks.Client{}
-	servicer := NewConstructionAPIService(cfg, mockClient)
+	cdc := app.MakeCodec()
+	servicer := NewConstructionAPIService(cfg, mockClient, cdc)
 	ctx := context.Background()
 
 	// Test Derive

--- a/services/construction_service_test.go
+++ b/services/construction_service_test.go
@@ -43,12 +43,6 @@ func TestConstructionService_Online(t *testing.T) {
 	assert.Equal(t, ErrUnimplemented.Code, err.Code)
 	assert.Equal(t, ErrUnimplemented.Message, err.Message)
 
-	// Test Preprocess
-	preprocessResponse, err := servicer.ConstructionPreprocess(ctx, &types.ConstructionPreprocessRequest{})
-	assert.Nil(t, preprocessResponse)
-	assert.Equal(t, ErrUnimplemented.Code, err.Code)
-	assert.Equal(t, ErrUnimplemented.Message, err.Message)
-
 	// Test Metadata
 	metadataResponse, err := servicer.ConstructionMetadata(ctx, &types.ConstructionMetadataRequest{})
 	assert.Nil(t, metadataResponse)
@@ -106,12 +100,6 @@ func TestConstructionService_Offline(t *testing.T) {
 	// Test Derive
 	deriveResponse, err := servicer.ConstructionDerive(ctx, &types.ConstructionDeriveRequest{})
 	assert.Nil(t, deriveResponse)
-	assert.Equal(t, ErrUnimplemented.Code, err.Code)
-	assert.Equal(t, ErrUnimplemented.Message, err.Message)
-
-	// Test Preprocess
-	preprocessResponse, err := servicer.ConstructionPreprocess(ctx, &types.ConstructionPreprocessRequest{})
-	assert.Nil(t, preprocessResponse)
 	assert.Equal(t, ErrUnimplemented.Code, err.Code)
 	assert.Equal(t, ErrUnimplemented.Message, err.Message)
 

--- a/services/errors.go
+++ b/services/errors.go
@@ -51,10 +51,23 @@ var (
 		Message: "Kava error",
 	}
 
-	// ErrNoOperations is return when no operations are provided
+	// ErrNoOperations is returned when no operations are provided
 	ErrNoOperations = &types.Error{
 		Code:    3,
 		Message: "No operations provided",
+	}
+
+	// ErrInvalidCurrency is returned when a currency value could not be parsed
+	ErrInvalidCurrencyAmount = &types.Error{
+		Code:    4,
+		Message: "Invalid currency",
+	}
+
+	// ErrUnsupportedCurrency is returned when a currency symbol is invalid
+	// or the decimals do not match
+	ErrUnsupportedCurrency = &types.Error{
+		Code:    5,
+		Message: "Unsupported concurrency",
 	}
 )
 

--- a/services/errors.go
+++ b/services/errors.go
@@ -50,6 +50,12 @@ var (
 		Code:    2,
 		Message: "Kava error",
 	}
+
+	// ErrNoOperations is return when no operations are provided
+	ErrNoOperations = &types.Error{
+		Code:    3,
+		Message: "No operations provided",
+	}
 )
 
 // wrapErr adds details to the types.Error provided. We use a function

--- a/services/errors.go
+++ b/services/errors.go
@@ -57,7 +57,7 @@ var (
 		Message: "No operations provided",
 	}
 
-	// ErrInvalidCurrency is returned when a currency value could not be parsed
+	// ErrInvalidCurrencyAmount is returned when a currency value could not be parsed
 	ErrInvalidCurrencyAmount = &types.Error{
 		Code:    4,
 		Message: "Invalid currency",

--- a/services/errors.go
+++ b/services/errors.go
@@ -69,6 +69,20 @@ var (
 		Code:    5,
 		Message: "Unsupported concurrency",
 	}
+
+	// ErrUnclearIntent is returned when operations
+	// provided in /construction/preprocess or /construction/payloads
+	// are not valid.
+	ErrUnclearIntent = &types.Error{
+		Code:    6,
+		Message: "Unable to parse intent",
+	}
+
+	// ErrInvalidAddress is returned when an account identifier has an invalid address
+	ErrInvalidAddress = &types.Error{
+		Code:    7,
+		Message: "Invalid Address",
+	}
 )
 
 // wrapErr adds details to the types.Error provided. We use a function

--- a/services/router.go
+++ b/services/router.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/server"
+	"github.com/kava-labs/kava/app"
 )
 
 // NewBlockchainRouter creates a Mux http.Handler from a collection
@@ -51,7 +52,8 @@ func NewBlockchainRouter(
 		asserter,
 	)
 
-	constructionAPIService := NewConstructionAPIService(config, client)
+	cdc := app.MakeCodec()
+	constructionAPIService := NewConstructionAPIService(config, client, cdc)
 	constructionAPIController := server.NewConstructionAPIController(
 		constructionAPIService,
 		asserter,

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -200,6 +200,281 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /construction/derive:
+    post:
+      summary: Derive an AccountIdentifier from a PublicKey
+      description: |
+        Derive returns the AccountIdentifier associated with a public key.
+
+        Blockchains that require an on-chain action to create an
+        account should not implement this method.
+      operationId: constructionDerive
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionDeriveRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstructionDeriveResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/preprocess:
+    post:
+      summary: Create a Request to Fetch Metadata
+      description: |
+        Preprocess is called prior to `/construction/payloads` to construct a
+        request for any metadata that is needed for transaction construction
+        given (i.e. account nonce).
+
+        The `options` object returned from this endpoint will be sent to the `/construction/metadata`
+        endpoint UNMODIFIED by the caller (in an offline execution environment). If
+        your Construction API implementation has configuration options, they MUST
+        be specified in the `/construction/preprocess` request (in the `metadata`
+        field).
+      operationId: constructionPreprocess
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionPreprocessRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstructionPreprocessResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/metadata:
+    post:
+      summary: Get Metadata for Transaction Construction
+      description: |
+        Get any information required to construct a transaction for a specific
+        network. Metadata returned here could be a recent hash to use, an
+        account sequence number, or even arbitrary chain state. The request
+        used when calling this endpoint is created by calling `/construction/preprocess`
+        in an offline environment.
+
+        You should NEVER assume that the request sent to this endpoint will be
+        created by the caller or populated with any custom parameters. This must
+        occur in `/construction/preprocess`.
+
+        It is important to clarify that this endpoint should not pre-construct
+        any transactions for the client (this should happen in `/construction/payloads`).
+        This endpoint is left purposely unstructured because of the wide scope
+        of metadata that could be required.
+      operationId: constructionMetadata 
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionMetadataRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstructionMetadataResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/payloads:
+    post:
+      summary: Generate an Unsigned Transaction and Signing Payloads
+      description: |
+        Payloads is called with an array of operations
+        and the response from `/construction/metadata`. It returns an
+        unsigned transaction blob and a collection of payloads that must
+        be signed by particular AccountIdentifiers using a certain SignatureType.
+
+        The array of operations provided in transaction construction often times
+        can not specify all "effects" of a transaction (consider invoked transactions
+        in Ethereum). However, they can deterministically specify the "intent"
+        of the transaction, which is sufficient for construction. For this reason,
+        parsing the corresponding transaction in the Data API (when it lands on chain)
+        will contain a superset of whatever operations were provided during construction.
+      operationId: constructionPayloads
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionPayloadsRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstructionPayloadsResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/combine:
+    post:
+      summary: Create Network Transaction from Signatures
+      description: |
+        Combine creates a network-specific transaction from an unsigned
+        transaction and an array of provided signatures.
+
+        The signed transaction returned from this method will be sent to the
+        `/construction/submit` endpoint by the caller.
+      operationId: constructionCombine
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionCombineRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstructionCombineResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/parse:
+    post:
+      summary: Parse a Transaction
+      description: |
+        Parse is called on both unsigned and signed transactions to
+        understand the intent of the formulated transaction.
+
+        This is run as a sanity check before signing (after `/construction/payloads`)
+        and before broadcast (after `/construction/combine`). 
+      operationId: constructionParse
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionParseRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstructionParseResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/hash:
+    post:
+      summary: Get the Hash of a Signed Transaction
+      description: |
+        TransactionHash returns the network-specific transaction hash for
+        a signed transaction.
+      operationId: constructionHash
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionHashRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionIdentifierResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /construction/submit:
+    post:
+      summary: Submit a Signed Transaction
+      description: |
+        Submit a pre-signed transaction to the node. This call should not block
+        on the transaction being included in a block. Rather, it should return
+        immediately with an indication of whether or not the transaction was
+        included in the mempool.
+
+        The transaction submission response should only return a 200 status
+        if the submitted transaction could be included in the mempool.
+        Otherwise, it should return an error.
+      operationId: constructionSubmit 
+      tags:
+        - Construction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConstructionSubmitRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionIdentifierResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   schemas:
     # Identifiers
@@ -448,6 +723,322 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TransactionIdentifier'
+    ConstructionMetadataRequest:
+      description: |
+        A ConstructionMetadataRequest is utilized to get information required
+        to construct a transaction.
+
+        The Options object used to specify which metadata to return is left
+        purposely unstructured to allow flexibility for implementers. Options
+        is not required in the case that there is network-wide metadata of
+        interest.
+
+        Optionally, the request can also include an array
+        of PublicKeys associated with the AccountIdentifiers
+        returned in ConstructionPreprocessResponse.
+      type: object
+      required:
+        - network_identifier
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        options:
+          description: |
+            Some blockchains require different metadata for different types of
+            transaction construction (ex: delegation versus a transfer). Instead
+            of requiring a blockchain node to return all possible types of
+            metadata for construction (which may require multiple node fetches),
+            the client can populate an options object to limit the metadata
+            returned to only the subset required.
+          type: object
+        public_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicKey'
+    ConstructionMetadataResponse:
+      description: |
+        The ConstructionMetadataResponse returns network-specific metadata
+        used for transaction construction.
+
+        Optionally, the implementer can return the suggested fee associated
+        with the transaction being constructed. The caller may use this info
+        to adjust the intent of the transaction or to create a transaction with
+        a different account that can pay the suggested fee. Suggested fee is an array
+        in case fee payment must occur in multiple currencies.
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          example:
+            account_sequence: 23
+        suggested_fee:
+          type: array
+          items:
+            $ref: '#/components/schemas/Amount'
+    ConstructionDeriveRequest:
+      description: |
+        ConstructionDeriveRequest is passed to the `/construction/derive`
+        endpoint. Network is provided in the request because some blockchains
+        have different address formats for different networks.
+        Metadata is provided in the request because some blockchains
+        allow for multiple address types (i.e. different address
+        for validators vs normal accounts).
+      type: object
+      required:
+        - network_identifier
+        - public_key
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        public_key:
+          $ref: '#/components/schemas/PublicKey'
+        metadata:
+          type: object
+    ConstructionDeriveResponse:
+      description: |
+        ConstructionDeriveResponse is returned by the `/construction/derive`
+        endpoint.
+      type: object
+      properties:
+        account_identifier:
+          $ref: '#/components/schemas/AccountIdentifier'
+        metadata:
+          type: object
+    ConstructionPreprocessRequest:
+      description: |
+        ConstructionPreprocessRequest is passed to the `/construction/preprocess`
+        endpoint so that a Rosetta implementation can determine which
+        metadata it needs to request for construction.
+
+        Metadata provided in this object should NEVER be a product
+        of live data (i.e. the caller must follow some network-specific
+        data fetching strategy outside of the Construction API to populate
+        required Metadata). If live data is required for construction, it MUST
+        be fetched in the call to `/construction/metadata`.
+
+        The caller can provide a max fee they are willing
+        to pay for a transaction. This is an array in the case fees
+        must be paid in multiple currencies.
+
+        The caller can also provide a suggested fee multiplier
+        to indicate that the suggested fee should be scaled.
+        This may be used to set higher fees for urgent transactions
+        or to pay lower fees when there is less urgency. It is assumed
+        that providing a very low multiplier (like 0.0001) will
+        never lead to a transaction being created with a fee
+        less than the minimum network fee (if applicable).
+
+        In the case that the caller provides both a max fee
+        and a suggested fee multiplier, the max fee will set an
+        upper bound on the suggested fee (regardless of the
+        multiplier provided).
+      type: object
+      required:
+        - network_identifier
+        - operations
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        operations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+        metadata:
+          type: object
+        max_fee:
+          type: array
+          items:
+            $ref: '#/components/schemas/Amount'
+        suggested_fee_multiplier:
+          type: number
+          format: double
+          minimum: 0.0
+    ConstructionPreprocessResponse:
+      description: |
+        ConstructionPreprocessResponse contains `options` that will
+        be sent unmodified to `/construction/metadata`. If it is
+        not necessary to make a request to `/construction/metadata`,
+        `options` should be omitted. 
+
+        Some blockchains require the PublicKey of particular AccountIdentifiers
+        to construct a valid transaction. To fetch these PublicKeys, populate
+        `required_public_keys` with the AccountIdentifiers associated with the desired
+        PublicKeys. If it is not necessary to retrieve any PublicKeys
+        for construction, `required_public_keys` should be omitted.
+      type: object
+      properties:
+        options:
+          type: object
+          description: |
+            The options that will be sent directly to `/construction/metadata` by
+            the caller.
+        required_public_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountIdentifier'
+    ConstructionPayloadsRequest:
+      description: |
+        ConstructionPayloadsRequest is the request to
+        `/construction/payloads`. It contains the network,
+        a slice of operations, and arbitrary metadata
+        that was returned by the call to `/construction/metadata`.
+
+        Optionally, the request can also include an array
+        of PublicKeys associated with the AccountIdentifiers
+        returned in ConstructionPreprocessResponse.
+      type: object
+      required:
+        - network_identifier
+        - operations
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        operations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+        metadata:
+          type: object
+        public_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicKey'
+    ConstructionPayloadsResponse:
+      description: |
+        ConstructionTransactionResponse is returned by `/construction/payloads`. It
+        contains an unsigned transaction blob (that is usually needed to construct
+        the a network transaction from a collection of signatures) and an
+        array of payloads that must be signed by the caller.
+      type: object
+      required:
+        - unsigned_transaction
+        - payloads
+      properties:
+        unsigned_transaction:
+          type: string
+        payloads:
+          type: array
+          items:
+            $ref: '#/components/schemas/SigningPayload'
+    ConstructionCombineRequest:
+      description: |
+        ConstructionCombineRequest is the input to the `/construction/combine`
+        endpoint. It contains the unsigned transaction blob returned by
+        `/construction/payloads` and all required signatures to create
+        a network transaction.
+      type: object
+      required:
+        - network_identifier
+        - unsigned_transaction
+        - signatures
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        unsigned_transaction:
+          type: string
+        signatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/Signature'
+    ConstructionCombineResponse:
+      description: |
+        ConstructionCombineResponse is returned by `/construction/combine`.
+        The network payload will be sent directly to the
+        `construction/submit` endpoint.
+      type: object
+      required:
+        - signed_transaction 
+      properties:
+        signed_transaction:
+          type: string
+    ConstructionParseRequest:
+      description: |
+        ConstructionParseRequest is the input to the `/construction/parse`
+        endpoint. It allows the caller to parse either an unsigned or
+        signed transaction.
+      type: object
+      required:
+        - network_identifier
+        - signed
+        - transaction
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        signed:
+          type: boolean
+          description: |
+            Signed is a boolean indicating whether the transaction is signed.
+        transaction:
+          type: string
+          description: |
+            This must be either the unsigned transaction blob returned by
+            `/construction/payloads` or the signed transaction blob
+            returned by `/construction/combine`.
+    ConstructionParseResponse:
+      description: |
+        ConstructionParseResponse contains an array of operations that occur in
+        a transaction blob. This should match the array of operations provided
+        to `/construction/preprocess` and `/construction/payloads`.
+      type: object
+      required:
+        - operations
+      properties:
+        operations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+        signers:
+          description: |
+            [DEPRECATED by `account_identifier_signers` in `v1.4.4`] All signers (addresses) of a particular transaction. If the transaction
+            is unsigned, it should be empty.
+          type: array
+          items:
+            type: string
+        account_identifier_signers:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountIdentifier'
+        metadata:
+          type: object
+    ConstructionHashRequest:
+      description: |
+        ConstructionHashRequest is the input to the `/construction/hash` endpoint.
+      type: object
+      required:
+        - network_identifier
+        - signed_transaction
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        signed_transaction:
+          type: string
+    ConstructionSubmitRequest:
+      description: |
+        The transaction submission request includes a signed transaction.
+      type: object
+      required:
+        - network_identifier
+        - signed_transaction
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        signed_transaction:
+          type: string
+    TransactionIdentifierResponse:
+      description: |
+        TransactionIdentifierResponse contains the transaction_identifier of a
+        transaction that was submitted to either `/construction/hash` or
+        `/construction/submit`.
+      type: object
+      required:
+        - transaction_identifier
+      properties:
+        transaction_identifier:
+          $ref: '#/components/schemas/TransactionIdentifier'
+        metadata:
+          type: object
 
     # Miscellaneous
     Error:

--- a/testing/construction_test.go
+++ b/testing/construction_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/kava-labs/kava/app"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +46,7 @@ func createTransferOperations(from string, to string, amount string) []*types.Op
 
 func TestTransfer(t *testing.T) {
 	ctx := context.Background()
+	cdc := app.MakeCodec()
 
 	// TODO: use /construction/dervice to generate bech32 addresses
 	operations := createTransferOperations(
@@ -74,4 +77,12 @@ func TestTransfer(t *testing.T) {
 	actualMemo, ok := preprocessResponse.Options["memo"].(string)
 	assert.True(t, ok)
 	assert.Equal(t, "test transfer integration", actualMemo)
+
+	maxFeeEncoded, ok := preprocessResponse.Options["max_fee"].(string)
+	assert.True(t, ok)
+
+	var maxFee sdk.Coins
+	err = cdc.UnmarshalJSON([]byte(maxFeeEncoded), &maxFee)
+	require.NoError(t, err)
+	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(500001))), maxFee)
 }

--- a/testing/construction_test.go
+++ b/testing/construction_test.go
@@ -1,0 +1,77 @@
+// +build integration
+// Copyright 2021 Kava Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTransferOperations(from string, to string, amount string) []*types.Operation {
+	return []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 0},
+			Type:                "transfer",
+			Account:             &types.AccountIdentifier{Address: from},
+			Amount:              &types.Amount{Value: amount, Currency: &types.Currency{Symbol: "KAVA", Decimals: 6}},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 1},
+			RelatedOperations:   []*types.OperationIdentifier{{Index: 0}},
+			Type:                "transfer",
+			Account:             &types.AccountIdentifier{Address: from},
+			Amount:              &types.Amount{Value: amount, Currency: &types.Currency{Symbol: "KAVA", Decimals: 6}},
+		},
+	}
+}
+
+func TestTransfer(t *testing.T) {
+	ctx := context.Background()
+
+	// TODO: use /construction/dervice to generate bech32 addresses
+	operations := createTransferOperations(
+		"kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea", // from
+		"kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w", // to
+		"1000001", // ukava amount
+	)
+
+	suggestedFeeMultipler := float64(0.5)
+
+	preprocessResponse, rosettaErr, err := client.ConstructionAPI.ConstructionPreprocess(ctx,
+		&types.ConstructionPreprocessRequest{
+			NetworkIdentifier:      config.NetworkIdentifier,
+			Operations:             operations,
+			MaxFee:                 []*types.Amount{{Value: "500001", Currency: &types.Currency{Symbol: "KAVA", Decimals: 6}}},
+			SuggestedFeeMultiplier: &suggestedFeeMultipler,
+			Metadata:               map[string]interface{}{"memo": "test transfer integration"},
+		},
+	)
+
+	require.Nil(t, rosettaErr)
+	require.NoError(t, err)
+
+	actualSuggestedFeeMultiplier, ok := preprocessResponse.Options["suggested_fee_multiplier"].(float64)
+	assert.True(t, ok)
+	assert.InDelta(t, suggestedFeeMultipler, actualSuggestedFeeMultiplier, 0.0000001)
+
+	actualMemo, ok := preprocessResponse.Options["memo"].(string)
+	assert.True(t, ok)
+	assert.Equal(t, "test transfer integration", actualMemo)
+}

--- a/testing/construction_test.go
+++ b/testing/construction_test.go
@@ -56,6 +56,7 @@ func TestTransfer(t *testing.T) {
 	)
 
 	suggestedFeeMultipler := float64(0.5)
+	gasAdjusment := float64(0.1)
 
 	preprocessResponse, rosettaErr, err := client.ConstructionAPI.ConstructionPreprocess(ctx,
 		&types.ConstructionPreprocessRequest{
@@ -63,7 +64,10 @@ func TestTransfer(t *testing.T) {
 			Operations:             operations,
 			MaxFee:                 []*types.Amount{{Value: "500001", Currency: &types.Currency{Symbol: "KAVA", Decimals: 6}}},
 			SuggestedFeeMultiplier: &suggestedFeeMultipler,
-			Metadata:               map[string]interface{}{"memo": "test transfer integration"},
+			Metadata: map[string]interface{}{
+				"memo":           "test transfer integration",
+				"gas_adjustment": gasAdjusment,
+			},
 		},
 	)
 
@@ -85,4 +89,8 @@ func TestTransfer(t *testing.T) {
 	err = cdc.UnmarshalJSON([]byte(maxFeeEncoded), &maxFee)
 	require.NoError(t, err)
 	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(500001))), maxFee)
+
+	actualGasAdjusment, ok := preprocessResponse.Options["gas_adjustment"].(float64)
+	assert.True(t, ok)
+	assert.InDelta(t, gasAdjusment, actualGasAdjusment, 0.0000001)
 }


### PR DESCRIPTION
Adds the /construction/preprocess endpoint for taking an array of operations with transaction related options, and parses them to return the options required for the metadata endpoint and the required account public keys.

In addition to the operations, and max fee.  The options endpoint also takes the:
  - max fee - the maximum transaction fee
  - suggested fee multiplier - A real number from 0 to 3 that the metadata endpoint uses to calculate gas price
  - gas adjustment - the percent to adjust the gas estimate
  - memo - the memo to set in the transaction

The options returned for the metadata are:
  - msgs - the array of messages built from the operations.  These are used to estimate gas in the metadata endpoint
  - gas_adjustment - passed to metadata to be used in gas estimation
  - max fee - used to adjust gas price to stay below max
  - memo - used to build tx for estimation