### PR TITLE
Failed Transaction Metadata, Exempt Account Additions, and Doc Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ To run in offline mode:
 docker run -it -e "MODE=offline" -e "NETWORK=kava-7" -e "PORT=8000" -p 8000:8000 rosetta-kava
 ```
 
+#### Snapshots
+
+Weekly archive node snapshots and instructions for quicker syncing are available at [https://kava.quicksync.io/](https://kava.quicksync.io/).
 
 ### Testnet
 

--- a/kava/client.go
+++ b/kava/client.go
@@ -253,8 +253,9 @@ func (c *Client) Block(
 }
 
 func (c *Client) getBlockDeliverResults(height *int64) (blockResults *ctypes.ResultBlockResults, err error) {
+	// backoff over 6,350 ms
 	backoff := 50 * time.Millisecond
-	for attempts := 0; attempts < 10; attempts++ {
+	for attempts := 0; attempts < 6; attempts++ {
 		blockResults, err = c.rpc.BlockResults(height)
 
 		if err != nil {

--- a/kava/client.go
+++ b/kava/client.go
@@ -332,12 +332,14 @@ func (c *Client) getTransactionsForBlock(
 		}
 
 		operations := c.getOperationsForTransaction(&tx, resultBlockResults.TxsResults[i])
+		metadata := c.getMetadataForTransaction(resultBlockResults.TxsResults[i])
 
 		transactions = append(transactions, &types.Transaction{
 			TransactionIdentifier: &types.TransactionIdentifier{
 				Hash: hash,
 			},
 			Operations: operations,
+			Metadata:   metadata,
 		})
 	}
 
@@ -387,6 +389,18 @@ func (c *Client) getOperationsForTransaction(
 	}
 
 	return TxToOperations(tx, logs, &feeStatus, &opStatus)
+}
+
+func (c *Client) getMetadataForTransaction(
+	result *abci.ResponseDeliverTx,
+) map[string]interface{} {
+	metadata := make(map[string]interface{})
+
+	if result.Code != abci.CodeTypeOK {
+		metadata["log"] = result.Log
+	}
+
+	return metadata
 }
 
 func stringifyEvents(events []abci.Event) sdk.StringEvents {

--- a/kava/client.go
+++ b/kava/client.go
@@ -254,7 +254,7 @@ func (c *Client) Block(
 
 func (c *Client) getBlockDeliverResults(height *int64) (blockResults *ctypes.ResultBlockResults, err error) {
 	backoff := 50 * time.Millisecond
-	for attempts := 0; attempts < 5; attempts++ {
+	for attempts := 0; attempts < 10; attempts++ {
 		blockResults, err = c.rpc.BlockResults(height)
 
 		if err != nil {

--- a/kava/client_test.go
+++ b/kava/client_test.go
@@ -740,10 +740,7 @@ func TestBlock_Transactions(t *testing.T) {
 	require.NoError(t, err)
 	mockDeliverTx2 := &abci.ResponseDeliverTx{
 		Code: 1,
-		Log: sdk.ABCIMessageLogs{
-			sdk.NewABCIMessageLog(0, "", []sdk.Event{}),
-			sdk.NewABCIMessageLog(1, "", []sdk.Event{}),
-		}.String(),
+		Log:  "some error message",
 	}
 
 	parentBlockIdentifier := &types.BlockIdentifier{
@@ -802,6 +799,16 @@ func TestBlock_Transactions(t *testing.T) {
 		assert.Equal(t, expectedHash, tx.TransactionIdentifier.Hash)
 
 		assert.Greater(t, len(tx.Operations), 1)
+
+		if mockDeliverTx.Code != 0 {
+			expectedLog := mockDeliverTx.Log
+			actualLog, ok := tx.Metadata["log"].(string)
+			require.True(t, ok)
+			assert.Equal(t, expectedLog, actualLog)
+		} else {
+			_, exists := tx.Metadata["log"]
+			assert.False(t, exists)
+		}
 
 		for index, operation := range tx.Operations {
 			currentIndex := int64(index)

--- a/kava/client_test.go
+++ b/kava/client_test.go
@@ -903,7 +903,7 @@ func TestBlock_BlockResultsRetry(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("retries a maximum of 5 times", func(t *testing.T) {
+	t.Run("retries a maximum of 6 times", func(t *testing.T) {
 		ctx := context.Background()
 		mockRPCClient, _, client := setupClient(t)
 
@@ -915,7 +915,7 @@ func TestBlock_BlockResultsRetry(t *testing.T) {
 		mockRPCClient.On("BlockResults", &blockIdentifier.Index).Return(
 			nil,
 			mockErr,
-		).Times(5)
+		).Times(6)
 
 		_, err = client.Block(ctx, &types.PartialBlockIdentifier{Index: &blockIdentifier.Index})
 		require.Error(t, err)

--- a/rosetta-cli-conf/kava-7/exempt_accounts.json
+++ b/rosetta-cli-conf/kava-7/exempt_accounts.json
@@ -10,6 +10,24 @@
   },
   {
     "account_identifier": {
+      "address":"kava1eu2ta269haf6j6z3lsj79a8rq3hsmnhu689g7z"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eu2ta269haf6j6z3lsj79a8rq3hsmnhu689g7z"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
       "address":"kava1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3fwaj0s"
     },
     "currency": {

--- a/rosetta-cli-conf/kava-testnet-12000/exempt_accounts.json
+++ b/rosetta-cli-conf/kava-testnet-12000/exempt_accounts.json
@@ -10,6 +10,24 @@
   },
   {
     "account_identifier": {
+      "address":"kava1eu2ta269haf6j6z3lsj79a8rq3hsmnhu689g7z"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eu2ta269haf6j6z3lsj79a8rq3hsmnhu689g7z"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
       "address":"kava1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3fwaj0s"
     },
     "currency": {

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -847,6 +847,23 @@ components:
             $ref: '#/components/schemas/Operation'
         metadata:
           type: object
+          properties:
+            gas_adjustment:
+              type: string
+              description: |
+                An optional decimal representing the amount to percent the estimated
+                gas when creating a transaction.
+
+                The default value is 0.5 and increases the gas estimated by 50%.  This
+                is the recommended value for the best reliability.
+              default: "0.5"
+              example: "0.2"
+            memo:
+              type: string
+              description: |
+                The memo set in the transaction, can be any string value under 256 bytes.
+              default: ""
+              example: "1234abcd"
         max_fee:
           type: array
           items:

--- a/swagger/models/Transaction.yaml
+++ b/swagger/models/Transaction.yaml
@@ -38,6 +38,11 @@ properties:
       Transactions that are related to other transactions (like a cross-shard transaction) should include
       the tranaction_identifier of these transactions in the metadata.
     type: object
+    properties:
+      log:
+        type: string
+        description: |
+          Error message provided when a transaction fails.  Not set for successful transactions where all operations succeed.
+        example: "insufficient funds to pay for fees"
     example:
-      size: 12378
-      lockTime: 1582272577
+      log: "insufficient funds to pay for fees"


### PR DESCRIPTION
- add preprocess metadata options to swagger
- add log message in transaction metadata for failed transactions
- update exempt accounts to exempt all native assets for the liquidation module acc
- add link to quicksync snapshot
- improve block retry test reliability
- increase number of retries for block result fetching
  - 6 retires total over ~6 seconds from 5 retries over ~3 seconds