### PR TITLE
Exempt all burner accounts and add native swp token to config

### DIFF
--- a/kava/types.go
+++ b/kava/types.go
@@ -129,6 +129,10 @@ var Currencies = map[string]*types.Currency{
 		Symbol:   "HARD",
 		Decimals: 6,
 	},
+	"swp": &types.Currency{
+		Symbol:   "SWP",
+		Decimals: 6,
+	},
 	"usdx": &types.Currency{
 		Symbol:   "USDX",
 		Decimals: 6,
@@ -139,6 +143,7 @@ var Currencies = map[string]*types.Currency{
 var Denoms = map[string]string{
 	"KAVA": "ukava",
 	"HARD": "hard",
+	"SWP":  "swp",
 	"USDX": "usdx",
 }
 

--- a/rosetta-cli-conf/kava-8/exempt_accounts.json
+++ b/rosetta-cli-conf/kava-8/exempt_accounts.json
@@ -28,6 +28,15 @@
   },
   {
     "account_identifier": {
+      "address":"kava1eu2ta269haf6j6z3lsj79a8rq3hsmnhu689g7z"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
       "address":"kava1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3fwaj0s"
     },
     "currency": {
@@ -50,6 +59,159 @@
     },
     "currency": {
       "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava10d07y265gmmuvt4z0w9aw880jnsr700jxh8cq5"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "SWP",
       "decimals": 6
     }
   }

--- a/rosetta-cli-conf/kava-testnet-13000/exempt_accounts.json
+++ b/rosetta-cli-conf/kava-testnet-13000/exempt_accounts.json
@@ -28,6 +28,15 @@
   },
   {
     "account_identifier": {
+      "address":"kava1eu2ta269haf6j6z3lsj79a8rq3hsmnhu689g7z"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
       "address":"kava1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3fwaj0s"
     },
     "currency": {
@@ -50,6 +59,159 @@
     },
     "currency": {
       "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava10d07y265gmmuvt4z0w9aw880jnsr700jxh8cq5"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1wq9ts6l7atfn45ryxrtg4a2gwegsh3xha9e6rp"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1eyugkwc74zejgwdwl7mvm7pad4hzdnka4wmdmu"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava1kuatfkj29h6fze6g2sqky8936rxu83yg3hn79g"
+    },
+    "currency": {
+      "symbol": "SWP",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "USDX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "KAVA",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "HARD",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address":"kava15asyc0tmjykt4phzggzcf2zekz2ymcwknh9gfd"
+    },
+    "currency": {
+      "symbol": "SWP",
       "decimals": 6
     }
   }


### PR DESCRIPTION
Add all burner address to exemptions, since these are untracked in cosmos-sdk v39 based chains.