### PR TITLE
Improve reliability of account balance queries for latest block height

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run: make test
 
     - name: Test Integration
-      run: KAVA_RPC_URL=https://rpc.kava.io:443 NETWORK=kava-9 PORT=4000 make test-integration
+      run: KAVA_RPC_URL=https://rpc.data.kava.io:443 NETWORK=kava-9 PORT=4000 make test-integration
 
   lint:
     name: lint

--- a/kava/account.go
+++ b/kava/account.go
@@ -49,12 +49,11 @@ func NewRPCBalanceFactory(rpc RPCClient) BalanceServiceFactory {
 					if attempts == maxAttempts-1 {
 						// return null balance if account is not found on the last attempt
 						return &nullBalance{}, nil
-					} else {
-						// increase backoff and try again
-						backoff = 2 * backoff
-						continue
 					}
 
+					// increase backoff and try again
+					backoff = 2 * backoff
+					continue
 				}
 				return nil, err
 			}


### PR DESCRIPTION
When under load, nodes may experience a race condition where the latest block is committed, but account results can not be queried yet.  This PR adds a test that hits this race condition, then enables retries to still return a non-zero balance when it occurs.  This is a temporary fix until we patch the root store of the node to fix the race condition and ensure queries do not return empty data after a height is commited.