### PR TITLE
fix: tx-timeout-height bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,9 @@ jobs:
     - name: Test Unit
       run: make test
 
-    - name: Test Integration
-      run: KAVA_RPC_URL=http://50.16.212.18:26658 NETWORK=kava-mainnet PORT=4000 make test-integration
+    # TODO(yevhenii): point KAVA_RPC_URL to running kava node and uncomment
+    # - name: Test Integration
+    #  run: KAVA_RPC_URL=http://50.16.212.18:26658 NETWORK=kava-mainnet PORT=4000 make test-integration
 
   lint:
     name: lint
@@ -50,35 +51,35 @@ jobs:
         with:
           args: --timeout 3m0s
 
-  Rosetta-Validation:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.21
-
-    - name: Cache Go Modules
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Start Rosetta Server
-      run: .github/scripts/setup.sh
-      shell: bash
-
-    - name: Run Check:construction test
-      run: .github/scripts/construction.sh
-      shell: bash
-
-    - name: Run Check:data test
-      run: .github/scripts/cli.sh
-      shell: bash
-
-    
+#  TODO(yevhenii): this is deprecated and doesn't work, remove? It also depends on the http://50.16.212.18:26658 node,
+#  which doesn't work at the moment.
+#  Rosetta-Validation:
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 15
+#    steps:
+#    - uses: actions/checkout@v3
+#
+#    - name: Set up Go
+#      uses: actions/setup-go@v2
+#      with:
+#        go-version: 1.21
+#
+#    - name: Cache Go Modules
+#      uses: actions/cache@v2
+#      with:
+#        path: ~/go/pkg/mod
+#        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+#        restore-keys: |
+#          ${{ runner.os }}-go-
+#
+#    - name: Start Rosetta Server
+#      run: .github/scripts/setup.sh
+#      shell: bash
+#
+#    - name: Run Check:construction test
+#      run: .github/scripts/construction.sh
+#      shell: bash
+#
+#    - name: Run Check:data test
+#      run: .github/scripts/cli.sh
+#      shell: bash

--- a/kava/client.go
+++ b/kava/client.go
@@ -26,6 +26,10 @@ import (
 	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	tmrpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
+	tmtypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -34,10 +38,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	kava "github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/app/params"
-	abci "github.com/cometbft/cometbft/abci/types"
-	ctypes "github.com/cometbft/cometbft/rpc/core/types"
-	tmrpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	tmtypes "github.com/cometbft/cometbft/types"
 )
 
 var noBlockResultsForHeight = regexp.MustCompile(`could not find results for height #(\d+)`)
@@ -395,7 +395,10 @@ func (c *Client) getOperationsForTransaction(
 
 	if result.Codespace == sdkerrors.RootCodespace {
 		switch result.Code {
-		case sdkerrors.ErrInvalidSequence.ABCICode(), sdkerrors.ErrInsufficientFee.ABCICode(), sdkerrors.ErrWrongSequence.ABCICode():
+		case sdkerrors.ErrInvalidSequence.ABCICode(),
+			sdkerrors.ErrInsufficientFee.ABCICode(),
+			sdkerrors.ErrTxTimeoutHeight.ABCICode(),
+			sdkerrors.ErrWrongSequence.ABCICode():
 			feeStatus = FailureStatus
 		// For unauthorized, insufficient funds, out of gas, we must check events in order to know if fee was paid or or not paid
 		case sdkerrors.ErrUnauthorized.ABCICode(), sdkerrors.ErrInsufficientFunds.ABCICode(), sdkerrors.ErrOutOfGas.ABCICode():


### PR DESCRIPTION
### Source code changes:

- main change is modification of `getOperationsForTransaction` function. Mark fee operations as failed if `tx-timeout-height` error was returned

- added `TestBlock_TxTimeoutHeight` unit-test which is based on `TestBlock_Transactions` test

- also I commented out deprecated parts of CI, which didn't work for quite some time
  - `Rosetta-Validation` job is deprecated and will be replaced with new approach
  - `Test Integration` relies on a node which doesn't work, and can be fixed as a separate task later