### PR TITLE
chore: fix integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,8 @@ jobs:
     - name: Test Unit
       run: make test
 
-    # TODO(yevhenii): point KAVA_RPC_URL to running kava node and uncomment
-    # - name: Test Integration
-    #  run: KAVA_RPC_URL=http://50.16.212.18:26658 NETWORK=kava-mainnet PORT=4000 make test-integration
+    - name: Test Integration
+      run: KAVA_RPC_URL=https://rpc.data.infra.kava.io:443 NETWORK=kava-mainnet PORT=4000 SKIP_RESOURCE_INTENSIVE_TESTS=true make test-integration
 
   lint:
     name: lint

--- a/testing/account_test.go
+++ b/testing/account_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -59,6 +60,10 @@ func TestAccountBalanceOffline(t *testing.T) {
 func TestAccountBalanceOnlineRetry(t *testing.T) {
 	if config.Mode.String() == "offline" {
 		t.Skip("skipping account online test")
+	}
+
+	if os.Getenv("SKIP_RESOURCE_INTENSIVE_TESTS") == "true" {
+		t.Skip("skipping account balance online retry test: it's resource intensive and produces a lot of requests to the node")
 	}
 
 	numJobs := 10

--- a/testing/retry_test.go
+++ b/testing/retry_test.go
@@ -39,6 +39,10 @@ func TestBlockRetry(t *testing.T) {
 		t.Skip("skipping block retry test: it's designed to be run against a live (mainnet) node")
 	}
 
+	if os.Getenv("SKIP_RESOURCE_INTENSIVE_TESTS") == "true" {
+		t.Skip("skipping block retry test: it's resource intensive and produces a lot of requests to the node")
+	}
+
 	numJobs := 10
 	jobCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
- fixed integration tests in CI by changing `KAVA_RPC_URL` from `http://50.16.212.18:26658` to `https://rpc.data.infra.kava.io:443`
- added `SKIP_RESOURCE_INTENSIVE_TESTS` environment variable to make sure we don't run `resource intensive` tests on every commit